### PR TITLE
[bug] `game_of_life_parameters`:set_default->{`help`}.to->{`0`};

### DIFF
--- a/sources/game_of_life_parameters.c
+++ b/sources/game_of_life_parameters.c
@@ -15,6 +15,8 @@ unsigned char game_of_life_parameters_parse(
   int length_parameters,
   const char** parameters
 ) {
+  game_of_life_parameters->help = 0;
+
   #if rendering_mode == 2
   struct cexil_size size_renderer;
   


### PR DESCRIPTION
- `game_of_life_parameters`:set_default->{`help`}.to->{`0`};
- - fixes an issue where the default value may not have been `0` depending on what the memory contents of the allocated variable was causing a prevention of running and instead only displaying the usage screen