### PR TITLE
[bug] `game_of_life_3d_on_initialize`:pass->{`fps_display`}.to->{`metil`:`rendering_properties`};

### DIFF
--- a/sources/game_of_life_3d_on_initialize.m
+++ b/sources/game_of_life_3d_on_initialize.m
@@ -23,6 +23,10 @@ void game_of_life_3d_on_initialize(
     @"game_of_life_3d_vertex"
   );
 
+  metil_renderer_interface->rendering_properties->fps_display = (
+    game_of_life_parameters->fps_display
+  );
+
   metil_renderer_interface->rendering_properties->camera.height = 0.0f;
 
   game_of_life_3d_scene_initialize(


### PR DESCRIPTION
- `game_of_life_3d_on_initialize`:pass->{`fps_display`}.to->{`metil`:`rendering_properties`};
- - fixes an issue where enabling the frames per second display did not get set in `metil`