### PR TITLE
[dev] Game of life parameters correct number of parameters

### DIFF
--- a/sources/game_of_life_parameters.c
+++ b/sources/game_of_life_parameters.c
@@ -59,7 +59,7 @@ unsigned char game_of_life_parameters_parse(
     int index_parameter_supplied = clic3_char_arrays_within(
       (char*) parameters[index_parameter],
       #if rendering_mode == 2
-      5,
+      4,
       #elif rendering_mode == 3
       6,
       #endif


### PR DESCRIPTION
- `game_of_life_parameters`:2d_parameter_count.set_to->{`4`};