### PR TITLE
[enh] lock_to_generation:add|implement

### DIFF
--- a/include/game_of_life.h
+++ b/include/game_of_life.h
@@ -20,6 +20,16 @@ int main(
 );
 
 #if rendering_mode == 2
+#if with_metal != 1
+void game_of_life_generate_initial_generation(
+  struct game_of_life_parameters*,
+  char**,
+  struct rand_parameters*,
+  struct rand_result*,
+  struct rand_source*
+);
+#endif
+
 void game_of_life_destroy(
   struct cexil_renderer*,
   struct game_of_life_parameters*,

--- a/include/game_of_life_3d_scene.h
+++ b/include/game_of_life_3d_scene.h
@@ -30,6 +30,7 @@ struct game_of_life_3d_scene_data {
 
   struct game_of_life_parameters* game_of_life_parameters;
 
+  struct rand_parameters rand_parameters;
   struct rand_result rand_result;
   struct rand_source rand_source;
 };
@@ -39,6 +40,12 @@ void game_of_life_3d_scene_initialize(
   id<MTLDevice>,
   struct game_of_life_parameters*
 );
+
+#if with_metal != 1
+void game_of_life_generate_initial_generation(
+  struct game_of_life_3d_scene_data*
+);
+#endif
 
 void game_of_life_3d_scene_poll(
   struct metil_scene*

--- a/include/game_of_life_metal_acceleration.h
+++ b/include/game_of_life_metal_acceleration.h
@@ -8,8 +8,11 @@
 
 void game_of_life_metal_acceleration_initialize(
   struct game_of_life_metal_acceleration_data*,
-  struct game_of_life_parameters*,
-  struct rand_result*
+  struct game_of_life_parameters*
+);
+
+void game_of_life_generate_initial_generation(
+  struct game_of_life_metal_acceleration_data*
 );
 
 void game_of_life_metal_acceleration_compute(

--- a/include/game_of_life_metal_acceleration_data.h
+++ b/include/game_of_life_metal_acceleration_data.h
@@ -3,6 +3,10 @@
 
 #include <game_of_life_metal_acceleration_data_error.h>
 
+#include <rand_parameters.h>
+#include <rand_result.h>
+#include <rand_source.h>
+
 struct game_of_life_metal_acceleration_data {
   void* metal_device;
   void* library;
@@ -16,7 +20,11 @@ struct game_of_life_metal_acceleration_data {
 
   char* cells;
   char* living_neighbors;
-  
+
+  struct rand_parameters* rand_parameters;
+  struct rand_result* rand_result;
+  struct rand_source* rand_source;
+
   enum game_of_life_metal_acceleration_data_error error;
 };
 

--- a/include/game_of_life_parameters.h
+++ b/include/game_of_life_parameters.h
@@ -4,6 +4,8 @@
 #include <clic3_vector.h>
 
 struct game_of_life_parameters {
+  unsigned int lock_to_generation;
+
   struct clic3_vector2_unsigned_int size;
   struct clic3_vector2_unsigned_int offset;
 

--- a/sources/game_of_life.c
+++ b/sources/game_of_life.c
@@ -147,25 +147,21 @@ int main(
     rand_source_type_divisive
   );
 
-  rand_get(
-    &rand_source,
-    &rand_result,
-    &rand_parameters
-  );
-
   #if with_metal == 1
   struct game_of_life_metal_acceleration_data game_of_life_metal_acceleration_data = {
     .metal_device = (void*)0,
     .library = (void*)0,
     .function_compute = (void*)0,
     .pipeline_state_compute = (void*)0,
-    .error = game_of_life_metal_acceleration_data_error_none
+    .error = game_of_life_metal_acceleration_data_error_none,
+    .rand_parameters = &rand_parameters,
+    .rand_result = &rand_result,
+    .rand_source = &rand_source
   };
 
   game_of_life_metal_acceleration_initialize(
     &game_of_life_metal_acceleration_data,
-    &game_of_life_parameters,
-    &rand_result
+    &game_of_life_parameters
   );
 
   if (
@@ -191,33 +187,13 @@ int main(
     game_of_life_parameters.size.y
   );
   #else
-  for (
-    unsigned int index_y = 0;
-    index_y < game_of_life_parameters.size.y;
-    ++index_y
-  ) {
-    unsigned long int offset_y = (
-      index_y *
-      game_of_life_parameters.size.x
-    );
-
-    for (
-      unsigned int index_x = 0;
-      index_x < game_of_life_parameters.size.x;
-      ++index_x
-    ) {
-      renderer.pixels[
-        index_y
-      ][
-        index_x
-      ] = game_of_life_cell_transform(
-        rand_result.bytes[
-          offset_y +
-          index_x
-        ]
-      );
-    }
-  }
+  game_of_life_generate_initial_generation(
+    &game_of_life_parameters,
+    renderer.pixels,
+    &rand_parameters,
+    &rand_result,
+    &rand_source
+  );
 
   char** cells_next = malloc(
     sizeof(unsigned char*) *
@@ -237,6 +213,13 @@ int main(
     );
   }
   #endif
+
+  unsigned int count_generations = (
+    game_of_life_parameters.lock_to_generation
+    ? game_of_life_parameters.lock_to_generation - 1
+    : 1
+  );
+  unsigned char first_render = 1;
 
   while (interrupt_handler_interrupted == 0) {
     #if with_metal == 1
@@ -258,22 +241,54 @@ int main(
     }
     #endif
 
-    cexil_renderer_render(
-      &renderer
-    );
+    if (
+      game_of_life_parameters.lock_to_generation < 2 ||
+      first_render == 0
+    ) {
+      cexil_renderer_render(
+        &renderer
+      );
+    }
+
+    if (
+      game_of_life_parameters.lock_to_generation != 0
+    ) {
+      #if with_metal == 1
+      game_of_life_generate_initial_generation(
+        &game_of_life_metal_acceleration_data
+      );
+      #else
+      game_of_life_generate_initial_generation(
+        &game_of_life_parameters,
+        renderer.pixels,
+        &rand_parameters,
+        &rand_result,
+        &rand_source
+      );
+      #endif
+    }
 
     #if with_metal == 1
     game_of_life_metal_acceleration_compute(
       &game_of_life_metal_acceleration_data,
       &game_of_life_parameters
     );
+
     #else
-    game_of_life_poll(
-      &game_of_life_parameters,
-      renderer.pixels,
-      cells_next
-    );
+    for (
+      unsigned int index_generated_generation = 0;
+      index_generated_generation < count_generations;
+      ++index_generated_generation
+    ) {
+      game_of_life_poll(
+        &game_of_life_parameters,
+        renderer.pixels,
+        cells_next
+      );
+    }
     #endif
+
+    first_render = 0;
   }
 
   game_of_life_destroy(
@@ -290,6 +305,52 @@ int main(
 
   return 0;
 }
+
+#if rendering_mode == 2
+#if with_metal != 1
+void game_of_life_generate_initial_generation(
+  struct game_of_life_parameters* game_of_life_parameters,
+  char** cells,
+  struct rand_parameters* rand_parameters,
+  struct rand_result* rand_result,
+  struct rand_source* rand_source
+) {
+  rand_get(
+    rand_source,
+    rand_result,
+    rand_parameters
+  );
+
+  for (
+    unsigned int index_y = 0;
+    index_y < game_of_life_parameters->size.y;
+    ++index_y
+  ) {
+    unsigned long int offset_y = (
+      index_y *
+      game_of_life_parameters->size.x
+    );
+
+    for (
+      unsigned int index_x = 0;
+      index_x < game_of_life_parameters->size.x;
+      ++index_x
+    ) {
+      cells[
+        index_y
+      ][
+        index_x
+      ] = game_of_life_cell_transform(
+        rand_result->bytes[
+          offset_y +
+          index_x
+        ]
+      );
+    }
+  }
+}
+#endif
+#endif
 
 void game_of_life_destroy(
   struct cexil_renderer* renderer,

--- a/sources/game_of_life_3d_scene.m
+++ b/sources/game_of_life_3d_scene.m
@@ -66,24 +66,14 @@ void game_of_life_3d_scene_initialize(
     game_of_life_3d_scene_data->game_of_life_parameters->size.y
   );
 
-
-  struct rand_parameters rand_parameters;
-
   rand_initialize(
-    &rand_parameters,
+    &game_of_life_3d_scene_data->rand_parameters,
     &game_of_life_3d_scene_data->rand_result,
     &game_of_life_3d_scene_data->rand_source,
     game_of_life_3d_scene_data->length_cells,
     rand_mode_bytes,
     rand_source_type_divisive
   );
-
-  rand_get(
-    &game_of_life_3d_scene_data->rand_source,
-    &game_of_life_3d_scene_data->rand_result,
-    &rand_parameters
-  );
-
 
   #if with_metal == 1
   game_of_life_3d_scene_data->game_of_life_metal_acceleration_data = malloc(
@@ -95,11 +85,13 @@ void game_of_life_3d_scene_initialize(
   game_of_life_3d_scene_data->game_of_life_metal_acceleration_data->function_compute = (void*)0;
   game_of_life_3d_scene_data->game_of_life_metal_acceleration_data->pipeline_state_compute = (void*)0;
   game_of_life_3d_scene_data->game_of_life_metal_acceleration_data->error = game_of_life_metal_acceleration_data_error_none;
+  game_of_life_3d_scene_data->game_of_life_metal_acceleration_data->rand_parameters = &game_of_life_3d_scene_data->rand_parameters;
+  game_of_life_3d_scene_data->game_of_life_metal_acceleration_data->rand_result = &game_of_life_3d_scene_data->rand_result;
+  game_of_life_3d_scene_data->game_of_life_metal_acceleration_data->rand_source = &game_of_life_3d_scene_data->rand_source;
 
   game_of_life_metal_acceleration_initialize(
     game_of_life_3d_scene_data->game_of_life_metal_acceleration_data,
-    game_of_life_3d_scene_data->game_of_life_parameters,
-    &game_of_life_3d_scene_data->rand_result
+    game_of_life_3d_scene_data->game_of_life_parameters
   );
 
   if (
@@ -139,29 +131,11 @@ void game_of_life_3d_scene_initialize(
       sizeof(unsigned char) *
       game_of_life_3d_scene_data->game_of_life_parameters->size.x
     );
-
-    unsigned long int offset_y = (
-      index_y *
-      game_of_life_3d_scene_data->game_of_life_parameters->size.x
-    );
-
-    for (
-      unsigned int index_x = 0;
-      index_x < game_of_life_3d_scene_data->game_of_life_parameters->size.x;
-      ++index_x
-    ) {
-      game_of_life_3d_scene_data->cells[
-        index_y
-      ][
-        index_x
-      ] = game_of_life_cell_transform(
-        game_of_life_3d_scene_data->rand_result.bytes[
-          offset_y +
-          index_x
-        ]
-      );
-    }
   }
+
+  game_of_life_generate_initial_generation(
+    game_of_life_3d_scene_data
+  );
   #endif
 
   scene->length_objects = game_of_life_3d_scene_data->length_cells;
@@ -327,6 +301,46 @@ void game_of_life_3d_scene_initialize(
   #endif
 }
 
+#if with_metal != 1
+void game_of_life_generate_initial_generation(
+  struct game_of_life_3d_scene_data* game_of_life_3d_scene_data
+) {
+  rand_get(
+    &game_of_life_3d_scene_data->rand_source,
+    &game_of_life_3d_scene_data->rand_result,
+    &game_of_life_3d_scene_data->rand_parameters
+  );
+  
+  for (
+    unsigned int index_y = 0;
+    index_y < game_of_life_3d_scene_data->game_of_life_parameters->size.y;
+    ++index_y
+  ) {
+    unsigned long int offset_y = (
+      index_y *
+      game_of_life_3d_scene_data->game_of_life_parameters->size.x
+    );
+
+    for (
+      unsigned int index_x = 0;
+      index_x < game_of_life_3d_scene_data->game_of_life_parameters->size.x;
+      ++index_x
+    ) {
+      game_of_life_3d_scene_data->cells[
+        index_y
+      ][
+        index_x
+      ] = game_of_life_cell_transform(
+        game_of_life_3d_scene_data->rand_result.bytes[
+          offset_y +
+          index_x
+        ]
+      );
+    }
+  }
+}
+#endif
+
 void game_of_life_3d_scene_poll(
   struct metil_scene* scene
 ) {
@@ -349,6 +363,20 @@ void game_of_life_3d_scene_poll(
   }
 
   game_of_life_3d_scene_data->frame = 0;
+
+  if (
+    game_of_life_parameters->lock_to_generation != 0
+  ) {
+    #if with_metal == 1
+    game_of_life_generate_initial_generation(
+      game_of_life_3d_scene_data->game_of_life_metal_acceleration_data
+    );
+    #else
+    game_of_life_generate_initial_generation(
+      game_of_life_3d_scene_data
+    );
+    #endif
+  }
 
   #if with_metal == 1
   game_of_life_metal_acceleration_compute(
@@ -390,95 +418,107 @@ void game_of_life_3d_scene_poll(
     data->color.z = data->color.x;
   }
   #else
+  unsigned int count_generations = (
+    game_of_life_parameters->lock_to_generation
+    ? game_of_life_parameters->lock_to_generation - 1
+    : 1
+  );
+
   for (
-    unsigned int index_y = 0;
-    index_y < game_of_life_parameters->size.y;
-    ++index_y
-  ) {
-    unsigned int offset_y = index_y * game_of_life_parameters->size.x;
-
+    unsigned int index_generated_generation = 0;
+    index_generated_generation < count_generations;
+    ++index_generated_generation
+  ) { 
     for (
-      unsigned int index_x = 0;
-      index_x < game_of_life_parameters->size.x;
-      ++index_x
+      unsigned int index_y = 0;
+      index_y < game_of_life_parameters->size.y;
+      ++index_y
     ) {
-      unsigned int living_neighbors = 0;
+      unsigned int offset_y = index_y * game_of_life_parameters->size.x;
 
-      const unsigned int index_object = offset_y + index_x;
-      
       for (
-        unsigned int index_neighbour_y = index_y == 0 ? 1 : index_y - 1;
-        index_neighbour_y < index_y + 2;
-        ++index_neighbour_y
+        unsigned int index_x = 0;
+        index_x < game_of_life_parameters->size.x;
+        ++index_x
       ) {
-        for (
-          unsigned int index_neighbour_x = index_x == 0 ? 1 : index_x - 1;
-          index_neighbour_x < index_x + 2;
-          ++index_neighbour_x
-        ) {
-          if (
-            (index_neighbour_y == index_y && index_neighbour_x == index_x) ||
-            index_neighbour_y >= game_of_life_parameters->size.y ||
-            index_neighbour_x >= game_of_life_parameters->size.x
-          ) {
-            continue;
-          }
+        unsigned int living_neighbors = 0;
 
-          if (
-            game_of_life_3d_scene_data->cells[index_neighbour_y][index_neighbour_x] == 1
+        const unsigned int index_object = offset_y + index_x;
+        
+        for (
+          unsigned int index_neighbour_y = index_y == 0 ? 1 : index_y - 1;
+          index_neighbour_y < index_y + 2;
+          ++index_neighbour_y
+        ) {
+          for (
+            unsigned int index_neighbour_x = index_x == 0 ? 1 : index_x - 1;
+            index_neighbour_x < index_x + 2;
+            ++index_neighbour_x
           ) {
-            living_neighbors = (
-              living_neighbors + 1
-            );
+            if (
+              (index_neighbour_y == index_y && index_neighbour_x == index_x) ||
+              index_neighbour_y >= game_of_life_parameters->size.y ||
+              index_neighbour_x >= game_of_life_parameters->size.x
+            ) {
+              continue;
+            }
+
+            if (
+              game_of_life_3d_scene_data->cells[index_neighbour_y][index_neighbour_x] == 1
+            ) {
+              living_neighbors = (
+                living_neighbors + 1
+              );
+            }
           }
         }
-      }
 
-      struct metil_renderer_data_object* data = scene->objects[
-        index_object
-      ]->data.contents;
-
-      if (
-        (game_of_life_3d_scene_data->cells[index_y][index_x] == 1 && living_neighbors == 2) || 
-        living_neighbors == 3
-      ) {
-        game_of_life_3d_scene_data->cells_next[index_y][index_x] = 1;
-
-        scene->objects[
+        struct metil_renderer_data_object* data = scene->objects[
           index_object
-        ]->position.z = 100.0f;
+        ]->data.contents;
 
-        data->color.x = (float) living_neighbors / 3.0f;
-        data->color.y = (float) living_neighbors / 3.0f;
-        data->color.z = (float) living_neighbors / 3.0f;
-      } else {
-        game_of_life_3d_scene_data->cells_next[index_y][index_x] = 0;
+        if (
+          (game_of_life_3d_scene_data->cells[index_y][index_x] == 1 && living_neighbors == 2) || 
+          living_neighbors == 3
+        ) {
+          game_of_life_3d_scene_data->cells_next[index_y][index_x] = 1;
 
-        data->color.x = (float) living_neighbors / 8.0f;
-        data->color.y = (float) living_neighbors / 16.0f;
-        data->color.z = (float) living_neighbors / 16.0f;
+          scene->objects[
+            index_object
+          ]->position.z = 100.0f;
 
-        scene->objects[
-          index_object
-        ]->position.z = (
-          101.0f + 8.0f - living_neighbors
-        );
+          data->color.x = (float) living_neighbors / 3.0f;
+          data->color.y = (float) living_neighbors / 3.0f;
+          data->color.z = (float) living_neighbors / 3.0f;
+        } else {
+          game_of_life_3d_scene_data->cells_next[index_y][index_x] = 0;
+
+          data->color.x = (float) living_neighbors / 8.0f;
+          data->color.y = (float) living_neighbors / 16.0f;
+          data->color.z = (float) living_neighbors / 16.0f;
+
+          scene->objects[
+            index_object
+          ]->position.z = (
+            101.0f + 8.0f - living_neighbors
+          );
+        }
       }
     }
-  }
 
-  for (
-    unsigned int index_y = 0;
-    index_y < game_of_life_parameters->size.y;
-    ++index_y
-  ) {
-    clic3_bytes_copy(
-      game_of_life_3d_scene_data->cells[index_y],
-      game_of_life_3d_scene_data->cells_next[index_y], (
-        sizeof(unsigned char) *
-        game_of_life_parameters->size.x
-      )
-    );
+    for (
+      unsigned int index_y = 0;
+      index_y < game_of_life_parameters->size.y;
+      ++index_y
+    ) {
+      clic3_bytes_copy(
+        game_of_life_3d_scene_data->cells[index_y],
+        game_of_life_3d_scene_data->cells_next[index_y], (
+          sizeof(unsigned char) *
+          game_of_life_parameters->size.x
+        )
+      );
+    }
   }
   #endif
 }

--- a/sources/game_of_life_metal_acceleration.m
+++ b/sources/game_of_life_metal_acceleration.m
@@ -6,7 +6,7 @@
 
 #include <clic3_vector.h>
 
-#include <rand_result.h>
+#include <rand_functions.h>
 
 #include <Metal/MTLBuffer.h>
 #include <Metal/MTLCommandBuffer.h>
@@ -17,8 +17,7 @@
 
 void game_of_life_metal_acceleration_initialize(
   struct game_of_life_metal_acceleration_data* game_of_life_metal_acceleration_data,
-  struct game_of_life_parameters* game_of_life_parameters,
-  struct rand_result* rand_result
+  struct game_of_life_parameters* game_of_life_parameters
 ) {
   game_of_life_metal_acceleration_data->error = (
     game_of_life_metal_acceleration_data_error_none
@@ -122,19 +121,19 @@ void game_of_life_metal_acceleration_initialize(
 
   game_of_life_metal_acceleration_data->buffer_cells = [
     (id<MTLDevice>) game_of_life_metal_acceleration_data->metal_device
-    newBufferWithLength: rand_result->length
+    newBufferWithLength: game_of_life_metal_acceleration_data->rand_result->length
     options: MTLResourceStorageModeShared
   ];
 
   game_of_life_metal_acceleration_data->buffer_cells_next = [
     (id<MTLDevice>) game_of_life_metal_acceleration_data->metal_device
-    newBufferWithLength: rand_result->length
+    newBufferWithLength: game_of_life_metal_acceleration_data->rand_result->length
     options: MTLResourceStorageModeShared
   ];
 
   game_of_life_metal_acceleration_data->buffer_living_neighbors = [
     (id<MTLDevice>) game_of_life_metal_acceleration_data->metal_device
-    newBufferWithLength: rand_result->length
+    newBufferWithLength: game_of_life_metal_acceleration_data->rand_result->length
     options: MTLResourceStorageModeShared
   ];
 
@@ -148,7 +147,7 @@ void game_of_life_metal_acceleration_initialize(
     (id<MTLDevice>) game_of_life_metal_acceleration_data->metal_device
     newBufferWithBytes: size
     length: sizeof(unsigned long int) * 3
-    options: MTLResourceStorageModePrivate
+    options: MTLResourceStorageModeShared
   ];
 
   if (
@@ -163,31 +162,57 @@ void game_of_life_metal_acceleration_initialize(
     return;
   }
 
-  char* cells = (
+  game_of_life_generate_initial_generation(
+    game_of_life_metal_acceleration_data
+  );
+
+  game_of_life_metal_acceleration_data->cells = (
     (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells
   ).contents;
 
-  for (
-    unsigned int index_cell = 0;
-    index_cell < rand_result->length;
-    ++index_cell
-  ) {
-    cells[
-      index_cell
-    ] = game_of_life_cell_transform(
-      rand_result->bytes[
-        index_cell
-      ]
-    );
-  }
+  game_of_life_metal_acceleration_data->living_neighbors = (
+    (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_living_neighbors
+  ).contents;
+}
+
+void game_of_life_generate_initial_generation(
+  struct game_of_life_metal_acceleration_data* game_of_life_metal_acceleration_data
+) {
+  rand_get(
+    game_of_life_metal_acceleration_data->rand_source,
+    game_of_life_metal_acceleration_data->rand_result,
+    game_of_life_metal_acceleration_data->rand_parameters
+  );
+
+  char* cells = (
+    (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells
+  ).contents;
 
   char* living_neighbors = (
     (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_living_neighbors
   ).contents;
 
+  unsigned long int* size = (
+    (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_size
+  ).contents;
+
   for (
     unsigned int index_cell = 0;
-    index_cell < rand_result->length;
+    index_cell < game_of_life_metal_acceleration_data->rand_result->length;
+    ++index_cell
+  ) {
+    cells[
+      index_cell
+    ] = game_of_life_cell_transform(
+      game_of_life_metal_acceleration_data->rand_result->bytes[
+        index_cell
+      ]
+    );
+  }
+
+  for (
+    unsigned int index_cell = 0;
+    index_cell < game_of_life_metal_acceleration_data->rand_result->length;
     ++index_cell
   ) {
     unsigned long int index_x = index_cell % size[0];
@@ -224,112 +249,125 @@ void game_of_life_metal_acceleration_initialize(
       }
     }
   }
-
-  game_of_life_metal_acceleration_data->cells = cells;
-  game_of_life_metal_acceleration_data->living_neighbors = living_neighbors;
 }
 
 void game_of_life_metal_acceleration_compute(
   struct game_of_life_metal_acceleration_data* game_of_life_metal_acceleration_data,
   struct game_of_life_parameters* game_of_life_parameters
 ) {
-  id<MTLCommandBuffer> buffer_command = [
-    (id<MTLCommandQueue>) game_of_life_metal_acceleration_data->command_queue
-    commandBuffer
-  ];
+  unsigned int length_generations = (
+    game_of_life_parameters->lock_to_generation == 0
+    ? 1
+    : game_of_life_parameters->lock_to_generation - 1
+  );
 
-  id<MTLComputeCommandEncoder> encoder_command_compute = [
-    buffer_command computeCommandEncoder
-  ];
+  for (
+    unsigned int index_generated_generations = 0;
+    index_generated_generations < length_generations;
+    ++index_generated_generations
+  ) {
+    id<MTLCommandBuffer> buffer_command = [
+      (id<MTLCommandQueue>) game_of_life_metal_acceleration_data->command_queue
+      commandBuffer
+    ];
 
-  [encoder_command_compute
-    setComputePipelineState: (
+    id<MTLComputeCommandEncoder> encoder_command_compute = [
+      buffer_command computeCommandEncoder
+    ];
+
+    [encoder_command_compute
+      setComputePipelineState: (
+        (id<MTLComputePipelineState>) (
+          game_of_life_metal_acceleration_data->pipeline_state_compute
+        )
+      )
+    ];
+
+    [encoder_command_compute
+      setBuffer: (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells
+      offset: 0
+      atIndex: 0
+    ];
+
+    [encoder_command_compute
+      setBuffer: (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells_next
+      offset: 0
+      atIndex: 1
+    ];
+
+    [encoder_command_compute
+      setBuffer: (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_living_neighbors
+      offset: 0
+      atIndex: 2
+    ];
+
+    [encoder_command_compute
+      setBuffer: (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_size
+      offset: 0
+      atIndex: 3
+    ];
+
+    unsigned long int length_buffer = (
+      (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells
+    ).length;
+
+    MTLSize size_grid = MTLSizeMake(
+      length_buffer,
+      1,
+      1
+    );
+
+    unsigned long int length_group_thread = (
       (id<MTLComputePipelineState>) (
         game_of_life_metal_acceleration_data->pipeline_state_compute
       )
-    )
-  ];
+    ).maxTotalThreadsPerThreadgroup;
 
-  [encoder_command_compute
-    setBuffer: (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells
-    offset: 0
-    atIndex: 0
-  ];
+    if (
+      length_buffer < length_group_thread
+    ) {
+      length_group_thread = length_buffer;
+    }
 
-  [encoder_command_compute
-    setBuffer: (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells_next
-    offset: 0
-    atIndex: 1
-  ];
+    MTLSize size_group_thread = MTLSizeMake(
+      length_group_thread,
+      1,
+      1
+    );
 
-  [encoder_command_compute
-    setBuffer: (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_living_neighbors
-    offset: 0
-    atIndex: 2
-  ];
+    [encoder_command_compute
+      dispatchThreads: size_grid
+      threadsPerThreadgroup: size_group_thread
+    ];
 
-  [encoder_command_compute
-    setBuffer: (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_size
-    offset: 0
-    atIndex: 3
-  ];
+    [encoder_command_compute endEncoding];
+    [buffer_command commit];
+    [buffer_command waitUntilCompleted];
 
-  unsigned long int length_buffer = (
-    (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells
-  ).length;
+    char* cells = (
+      (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells
+    ).contents;
 
-  MTLSize size_grid = MTLSizeMake(
-    length_buffer,
-    1,
-    1
-  );
+    char* cells_next = (
+      (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells_next
+    ).contents;
 
-  unsigned long int length_group_thread = (
-    (id<MTLComputePipelineState>) (
-      game_of_life_metal_acceleration_data->pipeline_state_compute
-    )
-  ).maxTotalThreadsPerThreadgroup;
-
-  if (
-    length_buffer < length_group_thread
-  ) {
-    length_group_thread = length_buffer;
+    for (
+      unsigned int index_cell = 0;
+      index_cell < length_buffer;
+      ++index_cell
+    ) {
+      cells[
+        index_cell
+      ] = cells_next[
+        index_cell
+      ];
+    }
   }
-
-  MTLSize size_group_thread = MTLSizeMake(
-    length_group_thread,
-    1,
-    1
-  );
-
-  [encoder_command_compute
-    dispatchThreads: size_grid
-    threadsPerThreadgroup: size_group_thread
-  ];
-
-  [encoder_command_compute endEncoding];
-  [buffer_command commit];
-  [buffer_command waitUntilCompleted];
 
   char* cells = (
     (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells
   ).contents;
-
-  char* cells_next = (
-    (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_cells_next
-  ).contents;
-
-  for (
-    unsigned int index_cell = 0;
-    index_cell < length_buffer;
-    ++index_cell
-  ) {
-    cells[
-      index_cell
-    ] = cells_next[
-      index_cell
-    ];
-  }
 
   char* living_neighbors = (
     (id<MTLBuffer>) game_of_life_metal_acceleration_data->buffer_living_neighbors

--- a/sources/game_of_life_parameters.c
+++ b/sources/game_of_life_parameters.c
@@ -15,6 +15,7 @@ unsigned char game_of_life_parameters_parse(
   int length_parameters,
   const char** parameters
 ) {
+  game_of_life_parameters->lock_to_generation = 0;
   game_of_life_parameters->help = 0;
 
   #if rendering_mode == 2
@@ -42,6 +43,7 @@ unsigned char game_of_life_parameters_parse(
   game_of_life_parameters->rate_poll = 0;
   #endif
 
+  unsigned char has_set_lock_to_generation = 0;
   unsigned char has_set_size_x = 0;
   unsigned char has_set_size_y = 0;
 
@@ -59,18 +61,17 @@ unsigned char game_of_life_parameters_parse(
     int index_parameter_supplied = clic3_char_arrays_within(
       (char*) parameters[index_parameter],
       #if rendering_mode == 2
-      4,
+      5,
       #elif rendering_mode == 3
-      6,
+      7,
       #endif
       "--size-x",
       "--size-y",
-      "--help"
+      "--help",
+      "--lock-to-generation",
       #if rendering_mode == 2
-      ,
       "--frame-rate"
       #elif rendering_mode == 3
-      ,
       "--audio",
       "--fps-display",
       "--rate-poll"
@@ -182,8 +183,45 @@ unsigned char game_of_life_parameters_parse(
 
         return 0;
       }
-      #if rendering_mode == 2
       case 3: {
+        if (
+          has_set_lock_to_generation == 1
+        ) {
+          fprintf(
+            stderr,
+            message_parameter_already_set,
+            parameters[index_parameter]
+          );
+          return 1;
+        }
+
+        index_parameter = (
+          index_parameter + 1
+        );
+
+        unsigned char status_int_conversion = clic3_char_array_to_unsigned_int(
+          (char*) parameters[index_parameter],
+          &game_of_life_parameters->lock_to_generation
+        );
+
+        if (
+          status_int_conversion != 0 ||
+          game_of_life_parameters->lock_to_generation < 1
+        ) {
+          fprintf(
+            stderr,
+            "invalid_lock_to_generation->{%s}\n",
+            parameters[index_parameter]
+          );
+
+          return 1;
+        }
+
+        has_set_lock_to_generation = 1;
+        break;
+      }
+      #if rendering_mode == 2
+      case 4: {
         if (
           has_set_frame_rate == 1
         ) {
@@ -222,7 +260,7 @@ unsigned char game_of_life_parameters_parse(
         break;
       }
       #elif rendering_mode == 3
-      case 3: {
+      case 4: {
         if (
           game_of_life_parameters->audio == 1
         ) {
@@ -238,7 +276,7 @@ unsigned char game_of_life_parameters_parse(
         game_of_life_parameters->audio = 1;
         break;
       }
-      case 4: {
+      case 5: {
         if (
           game_of_life_parameters->fps_display == 1
         ) {
@@ -254,7 +292,7 @@ unsigned char game_of_life_parameters_parse(
         game_of_life_parameters->fps_display = 1;
         break;
       }
-      case 5: {
+      case 6: {
         if (
           has_set_rate_poll == 1
         ) {

--- a/sources/game_of_life_print_usage.c
+++ b/sources/game_of_life_print_usage.c
@@ -81,15 +81,16 @@ void game_of_life_print_usage(
   fprintf(
     stream_output,
     "usage: %s\n"
-    "  --help                  : prints this usage information\n"
-    "  --size-x [#integer]     : sets the cell grid width\n"
-    "  --size-y [#integer]     : sets the cell grid height\n"
+    "  --help                          : prints this usage information\n"
+    "  --lock-to-generation [#integer] : regenerates and displays only a single generation\n"
+    "  --size-x [#integer]             : sets the cell grid width\n"
+    "  --size-y [#integer]             : sets the cell grid height\n"
     #if rendering_mode == 2
-    "  --frame-rate [#integer] : sets the frame rate\n"
+    "  --frame-rate [#integer]         : sets the frame rate\n"
     #elif rendering_mode == 3
-    "  --audio                 : enables audio output from buffered cell grid\n"
-    "  --fps-display           : enables the frames per second display\n"
-    "  --rate-poll [#integer]  : sets the rate in frames at which the cell grid is polled\n"
+    "  --audio                         : enables audio output from buffered cell grid\n"
+    "  --fps-display                   : enables the frames per second display\n"
+    "  --rate-poll [#integer]          : sets the rate in frames at which the cell grid is polled\n"
     #endif
     ,
     basename


### PR DESCRIPTION
locking to generation 1 in 3d with or without metal is a bit weird.

problem to solve for another day.

[game_of_life_2d_metal_accelerated.tar.gz](https://github.com/user-attachments/files/23491776/game_of_life_2d_metal_accelerated.tar.gz)
[game_of_life_2d.tar.gz](https://github.com/user-attachments/files/23491777/game_of_life_2d.tar.gz)
[game_of_life_3d_metal_accelerated.tar.gz](https://github.com/user-attachments/files/23491778/game_of_life_3d_metal_accelerated.tar.gz)
[game_of_life_3d.tar.gz](https://github.com/user-attachments/files/23491779/game_of_life_3d.tar.gz)
