### PR TITLE
[dev] Metil version bump

### DIFF
--- a/.github/workflows/continuous_integration_build.yml
+++ b/.github/workflows/continuous_integration_build.yml
@@ -18,7 +18,7 @@ env:
   key_cache_clic3: cache_clic3_0_0_0
   key_cache_interrupt_handler: cache_interrupt_handler_0_0_0
   key_cache_math_c: cache_math_c_0_0_0
-  key_cache_metil: cache_metil_0_0_0
+  key_cache_metil: cache_metil_3_0_0
   key_cache_rand: cache_rand_0_0_0
   target_device_version: 15.5
   target_metal_standard: metal3.2

--- a/.github/workflows/continuous_integration_build.yml
+++ b/.github/workflows/continuous_integration_build.yml
@@ -11,7 +11,7 @@ env:
   enabled_caching_clic3: 1
   enabled_caching_interrupt_handler: 1
   enabled_caching_math_c: 1
-  enabled_caching_metil: 0
+  enabled_caching_metil: 1
   enabled_caching_rand: 1
   key_cache_cer0: cache_cer0_0_0_0
   key_cache_cexil: cache_cexil_0_0_0

--- a/makefile
+++ b/makefile
@@ -119,7 +119,7 @@ version_target_cexil=0
 version_target_clic3=0
 version_target_interrupt_handler=0
 version_target_math_c=0
-version_target_metil=2
+version_target_metil=3
 version_target_rand=0
 
 file_clic3_library=${directory_clic3_library}/clic3.${version_target_clic3}.dylib


### PR DESCRIPTION
- `continuous_integration_build`
- - enable caching: `metil`
- - update cache key: `metil`
- `makefile`: update `metil` version to `3`